### PR TITLE
change documentation of daze.go

### DIFF
--- a/daze.go
+++ b/daze.go
@@ -311,7 +311,7 @@ type Locale struct {
 // reason, please use ServeSocks4 or ServeSocks5 instead. Why the poor
 // performance is that I did not implement http persistent connection( a well-known
 // name is KeepAlive) because It will trigger some bugs on Firefox. Firefox
-// will send traffic from different sites to the same long connection.
+// will send traffic from different sites to the same persistent connection.
 // I have been debugging for a long time.
 // Fuck.
 func (l *Locale) ServeProxy(connl io.ReadWriteCloser) error {

--- a/daze.go
+++ b/daze.go
@@ -309,7 +309,7 @@ type Locale struct {
 //
 // Warning: The performance of HTTP Proxy is very poor, unless you have a good
 // reason, please use ServeSocks4 or ServeSocks5 instead. Why the poor
-// performance is that I did not implement http long connection( a well-known
+// performance is that I did not implement http persistent connection( a well-known
 // name is KeepAlive) because It will trigger some bugs on Firefox. Firefox
 // will send traffic from different sites to the same long connection.
 // I have been debugging for a long time.


### PR DESCRIPTION
maybe it should be `http persistent connection` ,refer: https://en.wikipedia.org/wiki/HTTP_persistent_connection .When google search `http long`,it will prompt `http long-polling` which is the counterpart of websocket.