### PR TITLE
fix go get without go modules, rename lru

### DIFF
--- a/daze.go
+++ b/daze.go
@@ -228,7 +228,7 @@ func NewFilter(dialer Dialer) *Filter {
 	return &Filter{
 		Client: dialer,
 		NetBox: NetBox{},
-		Namedb: acdb.LRU(1024),
+		Namedb: acdb.Lru(1024),
 		Mold:   MoldIP,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mohanson/daze
 
-require github.com/mohanson/acdb v0.0.0-20181011082614-c8dd62f0727f
+require github.com/mohanson/acdb v0.0.0-20181107132025-4711ede81166

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/mohanson/acdb v0.0.0-20181011082614-c8dd62f0727f h1:G4eGQJ1L+zf+00P9zOOQdKJxOHEWh0vcW4LUzz1WXxM=
-github.com/mohanson/acdb v0.0.0-20181011082614-c8dd62f0727f/go.mod h1:SFSq3No783fJ1DC/zyAkX5/B2PQue+hv8betzCiV16w=
+github.com/mohanson/acdb v0.0.0-20181107132025-4711ede81166 h1:0JD8Os9dIUIDzr+tV2GgYhBOnJycwc+H0uAZM/Eaa8w=
+github.com/mohanson/acdb v0.0.0-20181107132025-4711ede81166/go.mod h1:SFSq3No783fJ1DC/zyAkX5/B2PQue+hv8betzCiV16w=


### PR DESCRIPTION
probably should also update the `go.mod` and `go.sum` files.