### PR TITLE
Refactor rate limiting applied to network connections

### DIFF
--- a/protocol/ashe/engine.go
+++ b/protocol/ashe/engine.go
@@ -234,9 +234,10 @@ func (s *Server) Run() error {
 			idx++
 			ctx := &daze.Context{Cid: idx}
 			log.Printf("conn: %08x accept remote=%s", ctx.Cid, cli.RemoteAddr())
-			rtc := &daze.RateConn{
-				Conn: cli,
-				Rate: s.Limits,
+			rtc := &daze.ReadWriteCloser{
+				Reader: io.TeeReader(cli, rate.NewLimitsWriter(s.Limits)),
+				Writer: io.MultiWriter(cli, rate.NewLimitsWriter(s.Limits)),
+				Closer: cli,
 			}
 			go func() {
 				defer rtc.Close()

--- a/protocol/czar/engine.go
+++ b/protocol/czar/engine.go
@@ -108,9 +108,10 @@ func (s *Server) Run() error {
 				}
 				break
 			}
-			rtc := &daze.RateConn{
-				Conn: cli,
-				Rate: s.Limits,
+			rtc := &daze.ReadWriteCloser{
+				Reader: io.TeeReader(cli, rate.NewLimitsWriter(s.Limits)),
+				Writer: io.MultiWriter(cli, rate.NewLimitsWriter(s.Limits)),
+				Closer: cli,
 			}
 			mux := NewMuxServer(rtc)
 			go func() {


### PR DESCRIPTION
This pull request refactors how rate limiting is applied to network connections throughout the codebase. The previous custom `RateConn` wrapper is removed and replaced with a more idiomatic approach using Go's standard IO interfaces (`io.TeeReader`, `io.MultiWriter`) to enforce rate limits on both reading and writing. This change impacts several server and client implementations, simplifying the code and improving maintainability.

**Rate Limiting Refactor:**

* Removed the custom `RateConn` type and its associated methods from `daze.go`, eliminating a bespoke implementation for rate limiting connections.
* Replaced all usages of `RateConn` in server and client code (`protocol/ashe/engine.go`, `protocol/baboon/engine.go`, `protocol/czar/engine.go`, `protocol/dahlia/engine.go`) with the standard `ReadWriteCloser` struct, which now utilizes `io.TeeReader` and `io.MultiWriter` combined with `rate.NewLimitsWriter` for rate limiting. [[1]](diffhunk://#diff-4529b1542ec2b36e6ee0f1e3a602c84934d15a6d57d5f46f587260eaf59e4d01L237-R240) [[2]](diffhunk://#diff-52d88ce5257696be3451f83322da8225f2826ce56591e84f51ffc0c1431c65dcL82-R85) [[3]](diffhunk://#diff-69037bed276606bb16cefede42456d4c73e5c39a449f121986a0399bf31826fcL111-R114) [[4]](diffhunk://#diff-5eaca9f4f21d889d44ae3140d4ff003476d7a59cee4f094b5fadc6d8e09b9805L73-R76) [[5]](diffhunk://#diff-5eaca9f4f21d889d44ae3140d4ff003476d7a59cee4f094b5fadc6d8e09b9805L151-R155)

**Code Consistency and Simplification:**

* Updated the instantiation of `ReadWriteCloser` to consistently use pointers (e.g., `&ReadWriteCloser{...}`) across all affected files for proper interface implementation and resource management. [[1]](diffhunk://#diff-2e09fd9db705bd341adc008c7b958c8050f0dc78ab3dd4afa8384cb2dff52718L595-R598) [[2]](diffhunk://#diff-2e09fd9db705bd341adc008c7b958c8050f0dc78ab3dd4afa8384cb2dff52718L609-R610)

These changes collectively modernize rate limiting logic and simplify connection handling, making the codebase easier to understand and maintain.